### PR TITLE
ci: adding vendor step to test action

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,6 +1,7 @@
 name: build-and-test
 
 on:
+    workflow_dispatch:
     pull_request_target:
 
 jobs:
@@ -14,6 +15,9 @@ jobs:
           uses: actions/setup-go@v4
           with:
             go-version: 1.20
+
+        - name: Vendor
+          run: go mod vendor
 
         - name: Build
           run: go build -v ./...


### PR DESCRIPTION
Adds vendoring step to test action so it pulls dependencies properly.